### PR TITLE
Add split hours for days

### DIFF
--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -63,7 +63,9 @@ export default function Calendar(props: Props) {
     let minHour, maxHour
     // get all active intervals
     for (const date of dates) {
-      const [earliest, latest] = timeRanges[date] ?? [9, 17]
+      if( earliest === undefined || latest === undefined) {
+        const [earliest, latest] = timeRanges[date] ?? [9, 17]
+      }
       // get start moment for day
       const hourPadded = earliest.toString().padStart(2, '0')
       let mmt = moment.tz(`${date} ${hourPadded}:00:00`, timezone)
@@ -111,7 +113,9 @@ export default function Calendar(props: Props) {
     let minHour, maxHour
     // get all active intervals
     for (const day of days) {
+      if( earliest === undefined || latest === undefined) {
         const [earliest, latest] = timeRanges[day.toString()] ?? [9, 17]
+      }
       for (let hour = earliest; hour < latest; hour++) {
         for (let minute = 0; minute < 60; minute += 15) {
           // set moment and switch timezone

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -13,6 +13,7 @@ type BaseBaseProps = {
   days?: number[]
   earliest: number
   latest: number
+  timeRanges: { [day: string]: number[] }
 }
 
 type BaseProps =
@@ -41,7 +42,7 @@ type CalendarDay = {
 }
 
 export default function Calendar(props: Props) {
-  const { timezone, currentTimezone, earliest, latest, type, datesType } = props
+  const { timezone, currentTimezone, earliest, latest,timeRanges, type, datesType } = props
 
   const [calendarDays, setCalendarDays] = useState<CalendarDay[]>([])
   const [hours, setHours] = useState<number[]>()
@@ -62,6 +63,7 @@ export default function Calendar(props: Props) {
     let minHour, maxHour
     // get all active intervals
     for (const date of dates) {
+      const [earliest, latest] = timeRanges[date] ?? [9, 17]
       // get start moment for day
       const hourPadded = earliest.toString().padStart(2, '0')
       let mmt = moment.tz(`${date} ${hourPadded}:00:00`, timezone)
@@ -96,7 +98,7 @@ export default function Calendar(props: Props) {
       fallBackHours,
       fallBackDates,
     }
-  }, [currentTimezone, datesType, earliest, latest, props.dates, timezone])
+  }, [currentTimezone, datesType, earliest, latest, timeRanges, props.dates, timezone])
 
   // updates days on calendar
   const updateDays = useCallback(() => {
@@ -109,6 +111,7 @@ export default function Calendar(props: Props) {
     let minHour, maxHour
     // get all active intervals
     for (const day of days) {
+        const [earliest, latest] = timeRanges[day.toString()] ?? [9, 17]
       for (let hour = earliest; hour < latest; hour++) {
         for (let minute = 0; minute < 60; minute += 15) {
           // set moment and switch timezone
@@ -142,7 +145,7 @@ export default function Calendar(props: Props) {
       fallBackHours,
       fallBackDates,
     }
-  }, [currentTimezone, datesType, earliest, latest, props.days, timezone])
+  }, [currentTimezone, datesType, earliest, latest, timeRanges, props.days, timezone])
 
   // returns hour parsed from YYYY-MM-DD HH:mm string
   function parseHour(date: string) {

--- a/components/Calendar.tsx
+++ b/components/Calendar.tsx
@@ -63,14 +63,18 @@ export default function Calendar(props: Props) {
     let minHour, maxHour
     // get all active intervals
     for (const date of dates) {
-      if( earliest === undefined || latest === undefined) {
-        const [earliest, latest] = timeRanges[date] ?? [9, 17]
+      let dateEarliest, dateLatest
+      if (timeRanges !== undefined) {
+        [dateEarliest, dateLatest] = timeRanges[date] ?? [9, 17]
+      } else {
+        dateEarliest = earliest
+        dateLatest = latest
       }
       // get start moment for day
-      const hourPadded = earliest.toString().padStart(2, '0')
+      const hourPadded = dateEarliest.toString().padStart(2, '0')
       let mmt = moment.tz(`${date} ${hourPadded}:00:00`, timezone)
       // continue in 15 minute intervals until latest hour reached
-      while (mmt.hour() < latest && mmt.format('YYYY-MM-DD') === date) {
+      while (mmt.hour() < dateLatest && mmt.format('YYYY-MM-DD') === date) {
         // clone moment into current timezone
         const currentMmt = mmt.clone().tz(currentTimezone)
         // update hour range
@@ -113,10 +117,14 @@ export default function Calendar(props: Props) {
     let minHour, maxHour
     // get all active intervals
     for (const day of days) {
-      if( earliest === undefined || latest === undefined) {
-        const [earliest, latest] = timeRanges[day.toString()] ?? [9, 17]
+      let dateEarliest, dateLatest
+      if (timeRanges !== undefined) {
+        [dateEarliest, dateLatest] =  timeRanges[day.toString()] ?? [9, 17]
+      } else {
+        dateEarliest = earliest
+        dateLatest = latest
       }
-      for (let hour = earliest; hour < latest; hour++) {
+      for (let hour = dateEarliest; hour < dateLatest; hour++) {
         for (let minute = 0; minute < 60; minute += 15) {
           // set moment and switch timezone
           const dayPadded = (day + 1).toString().padStart(2, '0')

--- a/components/TimeRanges.tsx
+++ b/components/TimeRanges.tsx
@@ -1,0 +1,49 @@
+import styles from "@/styles/pages/Index.module.scss";
+import TimeRangeSlider from "@/components/TimeRangeSlider";
+
+type Props = {
+    timeRanges: { [day: string]: number[] };
+    updateTimeRange: (day: string, newRange: number[]) => void;
+};
+
+
+function DayCard(props: { day: string }) {
+    const { day } = props;
+
+    let month = null;
+    let date = null;
+
+    if(day.length > 1) {
+        month = new Date(day).toLocaleString('default', {month: 'short'});
+        date = new Date(day).getDate();
+    }else{
+        const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        date = daysOfWeek[Number(day)];
+    }
+
+    return (
+        <div className={styles.calendarIcon}>
+            <div className={styles.month}>{month}</div>
+            <div className={styles.day}>{date}</div>
+        </div>
+    );
+}
+
+export default function TimeRanges(props: Props) {
+    const { timeRanges, updateTimeRange } = props;
+
+  return (
+      <>
+
+        {Object.keys(timeRanges).map((day) => (
+                    <div key={day} className={styles.timeRange}>
+                            <DayCard key={day} day={day}/>
+                             <TimeRangeSlider
+                              timeRange={timeRanges[day]}
+                              setTimeRange={(newRange) => updateTimeRange(day, newRange)}
+                          />
+                      </div>
+          ))}
+      </>
+  )
+}

--- a/components/TimeRanges.tsx
+++ b/components/TimeRanges.tsx
@@ -3,8 +3,7 @@ import TimeRangeSlider from "@/components/TimeRangeSlider";
 
 type Props = {
     timeRanges: { [day: string]: number[] },
-    updateTimeRange: (day: string, newRange: number[]) => void,
-    datesOption?: { label: string; value: string } | { label: string; value: string }
+    updateTimeRange: (day: string, newRange: number[]) => void
 };
 
 
@@ -14,9 +13,14 @@ function DayCard(props: { day: string }) {
     let month = null;
     let date = null;
 
+
     if (day.length > 1) {
-        month = new Date(day).toLocaleString('default', {month: 'short'});
-        date = new Date(day).getDate();
+        const utcDate = new Date(day)
+        const localDate = new Date(utcDate.getTime() + utcDate.getTimezoneOffset() * 60000)
+
+        month = localDate.toLocaleString('default', { month: 'short' });
+        date = localDate.toLocaleString('default', { day: 'numeric' });
+
     } else {
         const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
         date = daysOfWeek[Number(day)];

--- a/components/TimeRanges.tsx
+++ b/components/TimeRanges.tsx
@@ -2,21 +2,22 @@ import styles from "@/styles/pages/Index.module.scss";
 import TimeRangeSlider from "@/components/TimeRangeSlider";
 
 type Props = {
-    timeRanges: { [day: string]: number[] };
-    updateTimeRange: (day: string, newRange: number[]) => void;
+    timeRanges: { [day: string]: number[] },
+    updateTimeRange: (day: string, newRange: number[]) => void,
+    datesOption?: { label: string; value: string } | { label: string; value: string }
 };
 
 
 function DayCard(props: { day: string }) {
-    const { day } = props;
+    const {day} = props;
 
     let month = null;
     let date = null;
 
-    if(day.length > 1) {
+    if (day.length > 1) {
         month = new Date(day).toLocaleString('default', {month: 'short'});
         date = new Date(day).getDate();
-    }else{
+    } else {
         const daysOfWeek = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
         date = daysOfWeek[Number(day)];
     }
@@ -30,20 +31,20 @@ function DayCard(props: { day: string }) {
 }
 
 export default function TimeRanges(props: Props) {
-    const { timeRanges, updateTimeRange } = props;
+    const {timeRanges, updateTimeRange} = props;
 
-  return (
-      <>
+    return (
+        <>
 
-        {Object.keys(timeRanges).map((day) => (
-                    <div key={day} className={styles.timeRange}>
-                            <DayCard key={day} day={day}/>
-                             <TimeRangeSlider
-                              timeRange={timeRanges[day]}
-                              setTimeRange={(newRange) => updateTimeRange(day, newRange)}
-                          />
-                      </div>
-          ))}
-      </>
-  )
+            {Object.keys(timeRanges).map((day) => (
+                <div key={day} className={styles.timeRange}>
+                    <DayCard key={day} day={day}/>
+                    <TimeRangeSlider
+                        timeRange={timeRanges[day]}
+                        setTimeRange={(newRange) => updateTimeRange(day, newRange)}
+                    />
+                </div>
+            ))}
+        </>
+    )
 }

--- a/pages/[meetingId].tsx
+++ b/pages/[meetingId].tsx
@@ -96,7 +96,7 @@ export default function MeetingPage() {
   // copies invite link to clipboard
   async function copyLink() {
     if (!meeting) return
-    await navigator.clipboard.writeText(`https://meetingbrew.com/${meeting.id}`)
+    await navigator.clipboard.writeText(window.location.href)
     // show copy state
     if (copied) return
     setCopied(true)

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -160,6 +160,8 @@ const updateTimeRange = (day: string, newRange: number[]) => {
     const meetingId = id ? id : doc(meetingsRef).id.slice(0, 6).toLowerCase()
     const idLower = meetingId.toLowerCase()
     const meetingRef = doc(meetingsRef, idLower)
+    const earliest = -1
+    const latest = -1
     // create meeting
     const meetingBase = {
       id: meetingId,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -235,7 +235,7 @@ return (
               timezone={timezone}
               setTimezone={setTimezone}
             />
-            <TimeRanges timeRanges={timeRanges} updateTimeRange={updateTimeRange} />
+            <TimeRanges timeRanges={timeRanges} updateTimeRange={updateTimeRange} datesOption={datesOption}/>
           </div>
         </div>
         <div className={styles.options}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -115,6 +115,14 @@ const updateTimeRange = (day: string, newRange: number[]) => {
     titleInput.current?.focus()
   }, [])
 
+  useEffect( () => {
+    if(datesOption.value === 'days'){
+      setDaysAndManageTimeRanges(days);
+    }else{
+        setDatesAndManageTimeRanges(dates);
+    }
+  },[datesOption])
+
   // creates a new meeting in firebase
   async function createMeeting() {
     // if no title given
@@ -235,7 +243,7 @@ return (
               timezone={timezone}
               setTimezone={setTimezone}
             />
-            <TimeRanges timeRanges={timeRanges} updateTimeRange={updateTimeRange} datesOption={datesOption}/>
+            <TimeRanges timeRanges={timeRanges} updateTimeRange={updateTimeRange} />
           </div>
         </div>
         <div className={styles.options}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import DatesPicker from '@/components/DatesPicker'
 import DaysPicker from '@/components/DaysPicker'
 import Header from '@/components/Header'
-import TimeRangeSlider from '@/components/TimeRangeSlider'
+import TimeRanges from '@/components/TimeRanges'
 import TimezoneSelect from '@/components/TimezoneSelect'
 import styles from '@/styles/pages/Index.module.scss'
 import { selectStyles } from '@/util/styles'
@@ -41,12 +41,67 @@ export default function Index() {
   const [timeRange, setTimeRange] = useState<number[]>([9, 17])
   const [earliest, latest] = timeRange
 
+  // Update state to store time ranges for each day
+const [timeRanges, setTimeRanges] = useState<{ [day: string]: number[] }>({})
+
+// Function to add a new time range for a new day
+const addTimeRange = (day: string) => {
+  setTimeRanges({ ...timeRanges, [day]: [9, 17] })
+}
+
+// Function to remove a time range for a specific day
+const removeTimeRange = (day: string) => {
+  const { [day]: _, ...rest } = timeRanges
+  setTimeRanges(rest)
+}
+
+// Function to update a specific time range for a day
+const updateTimeRange = (day: string, newRange: number[]) => {
+  setTimeRanges({ ...timeRanges, [day]: newRange })
+}
+
   const titleInput = useRef<HTMLTextAreaElement>(null)
   const contentRef = useRef<HTMLDivElement>(null)
 
   const [datesOption, setDatesOption] = useState(datesOptions[0])
   const [dates, setDates] = useState<string[]>([])
   const [days, setDays] = useState<number[]>([])
+
+  // Function to set days and manage time ranges
+  const setDatesAndManageTimeRanges = (newDates: string[]) => {
+    setDates(newDates)
+    console.log(newDates)
+    const newTimeRanges: { [day: string]: number[] } = {}
+    newDates.forEach((day) => {
+      if (!timeRanges[day]) {
+        newTimeRanges[day] = [9, 17]
+      } else {
+        newTimeRanges[day] = timeRanges[day]
+      }
+    })
+    // sort the time range keys
+    const sortedTimeRanges: { [day: string]: number[] } = {}
+    Object.keys(newTimeRanges)
+      .sort()
+      .forEach((key) => {
+        sortedTimeRanges[key] = newTimeRanges[key]
+      })
+    setTimeRanges(sortedTimeRanges)
+  }
+
+  const setDaysAndManageTimeRanges = (newDays: number[]) => {
+    setDays(newDays)
+    const newTimeRanges: { [day: string]: number[] } = {}
+    newDays.forEach((day) => {
+      const dayString = day.toString()
+      if (!timeRanges[dayString]) {
+        newTimeRanges[dayString] = [9, 17]
+      } else {
+        newTimeRanges[dayString] = timeRanges[dayString]
+      }
+    })
+    setTimeRanges(newTimeRanges)
+  }
 
   const [mounted, setMounted] = useState(false)
 
@@ -112,6 +167,7 @@ export default function Index() {
       timezone,
       earliest,
       latest,
+      timeRanges,
       created: Date.now(),
     }
     const meeting: Meeting =
@@ -125,97 +181,95 @@ export default function Index() {
     Router.push(`/${meetingId}`)
   }
 
-  return (
-    <div className={styles.container}>
-      <Header className={styles.header} />
-      <div className={styles.outerContent}>
-        <div className={styles.content} ref={contentRef}>
-          <TextareaAutosize
-            className={styles.titleInput}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder='Event Title'
-            ref={titleInput}
-            wrap='hard'
-            maxLength={100}
-            onKeyDown={(e) => {
-              // prevent enter key
-              if (e.key === 'Enter') e.preventDefault()
-            }}
-            spellCheck='false'
-            data-gramm='false'
-          />
-          <div className={styles.datesTimes}>
-            <div className={styles.dates}>
-              <h2>Which dates?</h2>
-              <p>Date Type</p>
-              <Select
-                className={styles.select}
-                value={datesOption}
-                onChange={(val) => {
-                  if (val) setDatesOption(val)
+// Render multiple TimeRangeSliders based on selected days
+return (
+  <div className={styles.container}>
+    <Header className={styles.header} />
+    <div className={styles.outerContent}>
+      <div className={styles.content} ref={contentRef}>
+        <TextareaAutosize
+          className={styles.titleInput}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder='Event Title'
+          ref={titleInput}
+          wrap='hard'
+          maxLength={100}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') e.preventDefault()
+          }}
+          spellCheck='false'
+          data-gramm='false'
+        />
+        <div className={styles.datesTimes}>
+          <div className={styles.dates}>
+            <h2>Which dates?</h2>
+            <p>Date Type</p>
+            <Select
+              className={styles.select}
+              value={datesOption}
+              onChange={(val) => {
+                if (val) setDatesOption(val)
+              }}
+              options={datesOptions}
+              styles={selectStyles}
+              instanceId='select-dates'
+            />
+            {datesOption.value === 'dates' && mounted && (
+              <DatesPicker dates={dates} setDates={setDatesAndManageTimeRanges} />
+            )}
+            {datesOption.value === 'days' && mounted && (
+              <DaysPicker
+                days={days}
+                setDays={setDaysAndManageTimeRanges}
+              />
+            )}
+          </div>
+          <div className={styles.times}>
+            <h2>Which times?</h2>
+            <p>Timezone</p>
+            <TimezoneSelect
+              className={styles.select}
+              timezone={timezone}
+              setTimezone={setTimezone}
+            />
+            <TimeRanges timeRanges={timeRanges} updateTimeRange={updateTimeRange} />
+          </div>
+        </div>
+        <div className={styles.options}>
+          <div className={styles.idSection}>
+            <div className={styles.idInput}>
+              <p>MeetingBrew.com/ </p>
+              <input
+                value={id}
+                onChange={(e) => {
+                  let newId = e.target.value
+                  newId = newId.replaceAll(/[^\w -]/g, '')
+                  newId = newId.replaceAll(' ', '-')
+                  newId = newId.replaceAll('--', '-')
+                  setId(newId)
                 }}
-                options={datesOptions}
-                styles={selectStyles}
-                instanceId='select-dates'
-              />
-              {datesOption.value === 'dates' && mounted && (
-                <DatesPicker dates={dates} setDates={setDates} />
-              )}
-              {datesOption.value === 'days' && mounted && (
-                <DaysPicker days={days} setDays={setDays} />
-              )}
-            </div>
-            <div className={styles.times}>
-              <h2>Which times?</h2>
-              <p>Timezone</p>
-              <TimezoneSelect
-                className={styles.select}
-                timezone={timezone}
-                setTimezone={setTimezone}
-              />
-              <TimeRangeSlider
-                timeRange={timeRange}
-                setTimeRange={setTimeRange}
+                placeholder='custom ID (optional)'
+                maxLength={100}
+                spellCheck='false'
               />
             </div>
+            <p>
+              You can optionally set a custom id that will appear in the link
+              of your MeetingBrew.
+            </p>
           </div>
-          <div className={styles.options}>
-            <div className={styles.idSection}>
-              <div className={styles.idInput}>
-                <p>MeetingBrew.com/ </p>
-                <input
-                  value={id}
-                  onChange={(e) => {
-                    // clean up input id
-                    let newId = e.target.value
-                    newId = newId.replaceAll(/[^\w -]/g, '')
-                    newId = newId.replaceAll(' ', '-')
-                    newId = newId.replaceAll('--', '-')
-                    setId(newId)
-                  }}
-                  placeholder='custom ID (optional)'
-                  maxLength={100}
-                  spellCheck='false'
-                />
-              </div>
-              <p>
-                You can optionally set a custom id that will appear in the link
-                of your MeetingBrew.
-              </p>
-            </div>
-            <button onClick={createMeeting}>
-              <Image
-                src='/icons/add.svg'
-                width='24'
-                height='24'
-                alt='add.svg'
-              />
-              Create Event
-            </button>
-          </div>
+          <button onClick={createMeeting}>
+            <Image
+              src='/icons/add.svg'
+              width='24'
+              height='24'
+              alt='add.svg'
+            />
+            Create Event
+          </button>
         </div>
       </div>
     </div>
-  )
-}
+  </div>
+)}

--- a/styles/pages/Index.module.scss
+++ b/styles/pages/Index.module.scss
@@ -160,3 +160,40 @@
     }
   }
 }
+
+.timeRange {
+  display: flex;
+  margin-bottom: 1em;
+}
+
+.calendarIcon {
+  display: flex;
+  flex-direction: column;
+  width: 80px;
+  height: 80px;
+  border: 2px solid #333;
+  border-radius: 8px;
+  background-color: white;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  flex: 1 0 auto;
+  margin: 0 15px;
+}
+
+.month {
+  background-color: var(--mb-red);
+  color: white;
+  font-weight: bold;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  padding: 5px 0;
+  font-size: 14px;
+}
+
+.day {
+  font-size: 36px;
+  color: #333;
+  line-height: 50px;
+  flex: 1 1 auto;
+  align-content: center;
+}

--- a/util/types.ts
+++ b/util/types.ts
@@ -4,6 +4,7 @@ type BaseMeeting = {
   timezone: string
   earliest: number
   latest: number
+  timeRanges: { [day: string]: number[] }
   created: number
 }
 


### PR DESCRIPTION
This adds the ability to split hours on each of the selected days.
The time range selectors will have one for each date or each day that you've chosen. 

It should fall back to the single time range if it was a previously created poll. 

I created this fork at the request of a friend and thought it would be a useful feature to contribute back. 

Since it is hacktoberfest if you could label it hacktoberfest-accepted to qualify when merging that would be great!